### PR TITLE
Improve performance of parallel operations

### DIFF
--- a/grok_test.go
+++ b/grok_test.go
@@ -613,6 +613,18 @@ func BenchmarkCapturesTypedReal(b *testing.B) {
 	}
 }
 
+func BenchmarkParallelCaptures(b *testing.B) {
+	g, _ := NewWithConfig(&Config{NamedCapturesOnly: true})
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(b *testing.PB) {
+		for b.Next() {
+			g.Parse(`%{IPORHOST:clientip} %{USER:ident} %{USER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" %{NUMBER:response} (?:%{NUMBER:bytes}|-)`, `127.0.0.1 - - [23/Apr/2014:22:58:32 +0200] "GET /index.php HTTP/1.1" 404 207`)
+		}
+	})
+}
+
 func TestGrok_AddPatternsFromMap_not_exist(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
This PR replaces the main service mutex with two read write mutexes to improve the speed of parallel operations on already compiled expressions. All critical sections have been reduced to the bare minimum. This leads to a performance improvement of ~250% on parallel operations.

I added a new benchmark to be able to compare the speed and validity of parallel operations.
The results are as follows:

```
Master:
BenchmarkParallelCaptures-8    	    5000	    209069 ns/op	    4640 B/op	       5 allocs/op

This branch:
BenchmarkParallelCaptures-8    	   30000	     61049 ns/op	    4721 B/op	       5 allocs/op
```

Please note that no mutexes would be required if further API changes would be introduced to this library:
- Move the caching of compiled queries to the user (see #19)
- Disallow adding of new patterns after creation (if patterns need to be added, a new grok object could be created)

We created a fork that does exactly this but IMO contains too many other changes to be merged back to this repository. If you are interested, please see https://github.com/trivago/grok.