### PR TITLE
Added support for field names containing '-' and '.'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ _testmain.go
 .coveralls.yml
 # added by GitSavvy
 .DS_Store
+.idea
+*.i*

--- a/grok_test.go
+++ b/grok_test.go
@@ -209,6 +209,11 @@ func TestNamedCaptures(t *testing.T) {
 		"%{DAY:jour}",
 		"Tue May 15 11:21:42 [conn1047685] moveChunk deleted: 7157",
 	)
+
+	check("day-of.week", "Tue",
+		"%{DAY:day-of.week}",
+		"Tue May 15 11:21:42 [conn1047685] moveChunk deleted: 7157",
+	)
 }
 
 func TestErrorCaptureUnknowPattern(t *testing.T) {


### PR DESCRIPTION
This should fix #16 and also allow for future support for other characters that are outside of `[\w-.]`  set.