### PR TITLE
Fix regex for dependency handling

### DIFF
--- a/grok_test.go
+++ b/grok_test.go
@@ -225,6 +225,19 @@ func TestErrorCaptureUnknowPattern(t *testing.T) {
 	}
 }
 
+func TestErrorCaptureInvalidPattern(t *testing.T) {
+	g, _ := New()
+	pattern := "%{-InvalidPattern-}"
+	expectederr := "invalid pattern %{-InvalidPattern-}"
+	_, err := g.Parse(pattern, "")
+	if err == nil {
+		t.Fatal("Expected error not set")
+	}
+	if err.Error() != expectederr {
+		t.Fatalf("Expected error %q but got %q", expectederr, err.Error())
+	}
+}
+
 func TestParse(t *testing.T) {
 	g, _ := New()
 	g.AddPatternsFromPath("./patterns")


### PR DESCRIPTION
The current regexp used during dependency handling (`canonical`) does not parse patterns containing `.` and `-` correctly. As a consequence dependencies for custom patterns referencing other patterns containing dots / dashes or using an alias with dots / dashes such as `%{NUMBER:foo.bar}` end up being empty. This in turn leads to missing pattern errors when resolving the dependencies in `addPatternsFromMap()`. Those only occur randomly as described in https://github.com/vjeantet/grok/issues/24 due to access randomization in Golang when accessing a map.

This PR fixes https://github.com/vjeantet/grok/issues/24 and additionally perform a validity check on the pattern only accepting patterns/aliases starting and ending with a letter. Furthermore, a test is added checking invalid pattern handling.