### PR TITLE
fix: mutex added while accessing aliases map

### DIFF
--- a/grok.go
+++ b/grok.go
@@ -38,6 +38,7 @@ type Grok struct {
 	patterns         map[string]*gPattern
 	patternsGuard    *sync.RWMutex
 	compiledGuard    *sync.RWMutex
+	aliasGuard       *sync.RWMutex
 }
 
 type gPattern struct {
@@ -68,6 +69,7 @@ func NewWithConfig(config *Config) (*Grok, error) {
 		rawPattern:       map[string]string{},
 		patternsGuard:    new(sync.RWMutex),
 		compiledGuard:    new(sync.RWMutex),
+		aliasGuard:       new(sync.RWMutex),
 	}
 
 	if !config.SkipDefaultPatterns {
@@ -387,6 +389,8 @@ func (g *Grok) denormalizePattern(pattern string, storedPatterns map[string]*gPa
 
 func (g *Grok) aliasizePatternName(name string) string {
 	alias := symbolic.ReplaceAllString(name, "_")
+	g.aliasGuard.Lock()
+	defer g.aliasGuard.Unlock()
 	g.aliases[alias] = name
 	return alias
 }

--- a/grok.go
+++ b/grok.go
@@ -396,6 +396,8 @@ func (g *Grok) aliasizePatternName(name string) string {
 }
 
 func (g *Grok) nameToAlias(name string) string {
+	g.aliasGuard.Lock()
+	defer g.aliasGuard.Unlock()
 	alias, ok := g.aliases[name]
 	if ok {
 		return alias


### PR DESCRIPTION
The benchmarks fail due to concurrent access to the map. This PR fixes the issue.