### PR TITLE
Adding Nested fields support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,36 @@ COMMONAPACHELOG: 127.0.0.1 - - [23/Apr/2014:22:58:32 +0200] "GET /index.php HTTP
        clientip: 127.0.0.1
           ident: -
 ```
+
+# Example 3 - nested
+```go
+package main
+
+import (
+	"fmt"
+	"encoding/json"
+	"github.com/vjeantet/grok"
+)
+
+func main() {
+	g, _ = grok.NewWithConfig(&grok.Config{NamedCapturesOnly: true})
+	nested_values,_ := g.ParseTyped("%{TIME:time_stamp}: %{USER:[name][first_name]} is %{POSINT:[person][age]:int} years old and %{NUMBER:[person][height]:float} meters tall",`12:23:31: bob is 23 years old and 4.2 meters tall`)
+
+	j, _ := json.MarshalIndent(nested_values, "", "\t")
+	fmt.Println(string(j))
+}
+```
+
+output:
+```
+{
+	"name": {
+		"first_name": "bob"
+	},
+	"person": {
+		"age": 23,
+		"height": 4.2
+	},
+	"time_stamp": "12:23:31"
+}
+```

--- a/example/main.go
+++ b/example/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-
+	"encoding/json"
 	"github.com/vjeantet/grok"
 )
 
@@ -31,4 +31,11 @@ func main() {
 	for k, v := range values {
 		fmt.Printf("%+15s: %s\n", k, v)
 	}
+
+	fmt.Println("\n# Parse into a Nested map")
+	g, _ = grok.NewWithConfig(&grok.Config{NamedCapturesOnly: true})
+	nested_values,_ := g.ParseTyped("%{TIME:time_stamp}: %{USER:[name][first_name]} is %{POSINT:[person][age]:int} years old and %{NUMBER:[person][height]:float} meters tall",`12:23:31: bob is 23 years old and 4.2 meters tall`)
+
+	j, _ := json.MarshalIndent(nested_values, "", "\t")
+	fmt.Println(string(j))
 }

--- a/grok_test.go
+++ b/grok_test.go
@@ -599,6 +599,32 @@ func TestParseTypedWithAlias(t *testing.T) {
 	}
 }
 
+func TestParseTypedWithNested(t *testing.T) {
+	g,_ := NewWithConfig(&Config{NamedCapturesOnly: true})
+        if captures, err := g.ParseTyped("%{TIMESTAMP_ISO8601:time} %{USER:[user][name]}@%{HOSTNAME:[user][host]} %{WORD:action} %{POSINT:[net][bytes]:int} bytes from %{IP:[net][source][ip]}:%{POSINT:[net][source][port]:int}","2023-04-08T11:55:00+0200 john.doe@example.com send 230 bytes from 198.51.100.65:2342"); err != nil {
+		t.Fatalf("error can not capture : %s", err.Error())
+	} else {
+		expected := map[string]interface{}{
+			"time": "2023-04-08T11:55:00+0200",
+                        "action": "send",
+			"user": map[string]interface{}{
+				   "name": "john.doe",
+				   "host": "example.com",
+				},
+			"net": map[string]interface{}{
+				   "bytes": 230,
+                                   "source": map[string]interface{}{
+					"ip": "198.51.100.65",
+					"port": 2342,
+				   },
+				},
+		}
+		if fmt.Sprint(expected) != fmt.Sprint(captures) {
+			t.Fatalf("Expected nested map: %s got %s", expected, captures)
+		}
+	}
+}
+
 var resultNew *Grok
 
 func BenchmarkNew(b *testing.B) {


### PR DESCRIPTION
This adds support to parse into nested _map[string]interface{}_ maps when using ParseTyped().

It implements what's requested in Issue #35. Though only for gork.ParseTyped(). The functionality was  deliberately **NOT**  implemented for grok.Parse() as it returns a _map[string]string_ but for the nesting functionality _map[string]interface{}_ is needed. Thus it would break backwards compatibility.

 